### PR TITLE
Escaping character causing failure - pyansys install

### DIFF
--- a/src/ansys/tools/installer/installed_table.py
+++ b/src/ansys/tools/installer/installed_table.py
@@ -207,7 +207,7 @@ class InstalledTab(QtWidgets.QWidget):
 
     def install_pyansys(self):
         """Install PyAnsys metapackage."""
-        cmd = "pip install pyansys>=2023 & timeout 3 & exit || echo Failed to install PyAnsys metapackage. Try reinstalling it with pip install pyansys>=2023 --force-reinstall"
+        cmd = "pip install pyansys^>=2023 & timeout 3 & exit || echo Failed to install PyAnsys metapackage. Try reinstalling it with pip install pyansys^>=2023 --force-reinstall"
         self.launch_cmd(cmd)
 
     def list_packages(self):


### PR DESCRIPTION
Installion proceeded but the cmd was failing. This fixes #17 