### PR TITLE
use ansys-tool-path, instead of using the env variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "appdirs",
     "requests",
     "PySide6",
+    "ansys-tools-path"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/ansys/tools/installer/constants.py
+++ b/src/ansys/tools/installer/constants.py
@@ -25,8 +25,6 @@ PYANSYS_DOCS_TEXT = f"""<h2>PyAnsys Documentation</h2>
 
 ANSYS_VENVS = ".ansys_python_venvs"
 
-ANSYS_ENV_VAR_START = "awp_root"
-
 ANSYS_SUPPORTED_PYTHON_VERSIONS = ["3_7", "3_10"]
 
 INSTALL_TEXT = """Choose to use either the standard Python install from <a href='https://www.python.org/'>python.org</a> or <a href='https://github.com/conda-forge/miniforge'>miniforge</a>."""

--- a/src/ansys/tools/installer/find_python.py
+++ b/src/ansys/tools/installer/find_python.py
@@ -5,8 +5,8 @@ import os
 from pathlib import Path
 import subprocess
 
+from ansys.tools.path import get_available_ansys_installations
 from ansys.tools.installer.constants import (
-    ANSYS_ENV_VAR_START,
     ANSYS_SUPPORTED_PYTHON_VERSIONS,
     ANSYS_VENVS,
 )
@@ -104,21 +104,13 @@ def _find_installed_python_win(admin=False):
     return paths
 
 
-def _find_installed_ansys_win():
-    """Check the environment variables for Ansys installations."""
-    env_keys = []
-    for key in os.environ.keys():
-        if key.lower().startswith(ANSYS_ENV_VAR_START):
-            env_keys.append(key)
-    return env_keys
-
 
 def _find_installed_ansys_python_win():
     """Check the Ansys installation folder for installed Python."""
-    installed_ansys = _find_installed_ansys_win()
+    installed_ansys = get_available_ansys_installations()
     paths = {}
-    for ansys_ver_env_key in installed_ansys:
-        ansys_path = os.environ[ansys_ver_env_key]
+    for ver in installed_ansys:
+        ansys_path = installed_ansys[ver]
         for ansys_py_ver in ANSYS_SUPPORTED_PYTHON_VERSIONS:
             path = os.path.join(
                 ansys_path,


### PR DESCRIPTION
updated the installer code, so that it uses [ansys-tools-path](https://github.com/ansys/ansys-tools-path)library to deduce the versions that are installed, and then checks for the python that is available.

PS: I was able to make the builds with following

on windows

- make build
- and then compile setup.nsis with NSIS local installaion 
