### PR TITLE
fix: white space in user path

### DIFF
--- a/src/ansys/tools/installer/installer.py
+++ b/src/ansys/tools/installer/installer.py
@@ -38,5 +38,5 @@ def run_ps(command, full_path_to_ps=False):
 def install_python(filename, wait=True):
     """Install "vanilla" python for a single user."""
     wait_str = " -Wait" if wait else ""
-    command = f'(Start-Process {filename} -ArgumentList "/passive InstallAllUsers=0" {wait_str})'
+    command = f"(Start-Process '{filename}' -ArgumentList '/passive InstallAllUsers=0' {wait_str})"
     return run_ps(command)

--- a/src/ansys/tools/installer/main.py
+++ b/src/ansys/tools/installer/main.py
@@ -230,7 +230,7 @@ class AnsysPythonInstaller(QtWidgets.QMainWindow):
     @protected
     def _exe_update(self, filename):
         """After downloading the update for this application, run the file and shutdown this application."""
-        run_ps(f"(Start-Process {filename})")
+        run_ps(f"(Start-Process '{filename}')")
 
         # exiting
         LOG.debug("Closing...")


### PR DESCRIPTION
If user has white space in the user name then we  need to encapsulate the path in quotes

