### PR TITLE
fedora build fix, revert to fedora:40

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Install CentOS/Fedora Dependencies
         if: contains(matrix.os, 'centos') || contains(matrix.os, 'fedora')
-        run: |          
+        run: |
           yum install python3 \
             python3-pip \
             wget \

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -469,11 +469,10 @@ jobs:
           name: Python-Installer-centos_stream9
           path: installer
 
-      # TODO: reactivate...
-      # - uses: actions/download-artifact@v4
-      #   with:
-      #     name: Python-Installer-fedora_latest
-      #     path: installer
+      - uses: actions/download-artifact@v4
+        with:
+          name: Python-Installer-fedora_latest
+          path: installer
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -237,9 +237,7 @@ jobs:
   build-application-linux-non-debian:
     strategy:
       matrix:
-        # TODO: reactivate...
-        # os: ["quay.io/centos/centos:stream9", "fedora:latest"]
-        os: ["quay.io/centos/centos:stream9"]
+        os: ["quay.io/centos/centos:stream9", "fedora:40"]
       fail-fast: false
     name: "Build Application Linux - ${{ matrix.os }}"
     runs-on: ubuntu-latest
@@ -251,11 +249,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install CentOS/Fedora Dependencies
-        if: contains(matrix.os, 'centos') || contains(matrix.os, 'fedora')
+      - name: Update and Install development tools - Fedora
+        if: contains(matrix.os, 'fedora')
+        run: |
+          yum update -y
+          yum group install development-tools -y
+
+      - name: Update and Install development tools - Centos
+        if: contains(matrix.os, 'centos')
         run: |
           yum update -y
           yum groupinstall "Development Tools" -y
+
+      - name: Install CentOS/Fedora Dependencies
+        if: contains(matrix.os, 'centos') || contains(matrix.os, 'fedora')
+        run: |          
           yum install python3 \
             python3-pip \
             wget \


### PR DESCRIPTION
The rpmbuild issue is due to fedora image upgrade to 41 (latest). 
As there is no concrete fix for this yet from fedora team, I am downgrading the fedora image to fedora:40
The gcc version remains the same hence this package should work fine for all users.