### PR TITLE
Uv bugfix

### DIFF
--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -54,18 +54,30 @@ def create_venv_windows(venv_dir: str, py_path: str):
     try:
         print("Updating package managers...")
         print(f"New PATH: {new_path.split(';')[1]}")
+        # Backup method
         subprocess.call(
-            f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
+            f'{new_path.split(";")[1]}\python.exe -m pip install --upgrade pip uv && exit',
             shell=True,
             cwd=user_profile,
         )
-
         # Create venv using uv
         subprocess.call(
-            f'start /w /min cmd /K "set PATH={new_path} && python -m uv venv {venv_dir} && exit"',
+            f'{new_path.split(";")[1]}\python.exe -m uv venv {venv_dir} && exit"',
             shell=True,
             cwd=user_profile,
         )
+        # subprocess.call(
+        #     f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
+        #     shell=True,
+        #     cwd=user_profile,
+        # )
+
+        # # Create venv using uv
+        # subprocess.call(
+        #     f'start /w /min cmd /K "set PATH={new_path} && python -m uv venv {venv_dir} && exit"',
+        #     shell=True,
+        #     cwd=user_profile,
+        # )
     except Exception as e:
         print(f"Error creating virtual environment: {e}")
         

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -56,13 +56,13 @@ def create_venv_windows(venv_dir: str, py_path: str):
         print(f"New PATH: {new_path.split(';')[1]}")
         # Backup method
         subprocess.call(
-            f'{new_path.split(";")[1]}\python.exe -m pip install --upgrade pip uv && exit',
+            f'"{new_path.split(";")[1]}\python.exe" -m pip install --upgrade pip uv && exit',
             shell=True,
             cwd=user_profile,
         )
         # Create venv using uv
         subprocess.call(
-            f'{new_path.split(";")[1]}\python.exe -m uv venv {venv_dir} && exit"',
+            f'"{new_path.split(";")[1]}\python.exe" -m uv venv {venv_dir} && exit"',
             shell=True,
             cwd=user_profile,
         )

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -52,10 +52,26 @@ def create_venv_windows(venv_dir: str, py_path: str):
     
     # Update the package managers
     try:
-        print("Updating package managers...")
+        LOG.debug("Updating package managers - pip & uv...")
+        subprocess.call(
+            f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
+            shell=True,
+            cwd=user_profile,
+        )
+
+        # Create venv using uv
+        LOG.debug("Creating virtual environment using uv...")
+        subprocess.call(
+            f'start /w /min cmd /K "set PATH={new_path} && python -m uv venv {venv_dir} && exit"',
+            shell=True,
+            cwd=user_profile,
+        )
+    except Exception as e:
+        LOG.debug(f"Error creating virtual environment: {e}")
+        LOG.debug("Trying to create virtual environment using backup method...")
         
         new_path = new_path.split(";")[0] + "\python.exe"
-        print(f"New path: {new_path}")
+        
         # Backup method
         subprocess.call(
             f'"{new_path}" -m pip install --upgrade pip uv && exit',
@@ -65,33 +81,6 @@ def create_venv_windows(venv_dir: str, py_path: str):
         # Create venv using uv
         subprocess.call(
             f'"{new_path}" -m uv venv {venv_dir} && exit',
-            shell=True,
-            cwd=user_profile,
-        )
-        # subprocess.call(
-        #     f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
-        #     shell=True,
-        #     cwd=user_profile,
-        # )
-
-        # # Create venv using uv
-        # subprocess.call(
-        #     f'start /w /min cmd /K "set PATH={new_path} && python -m uv venv {venv_dir} && exit"',
-        #     shell=True,
-        #     cwd=user_profile,
-        # )
-    except Exception as e:
-        print(f"Error creating virtual environment: {e}")
-        
-        # Backup method
-        subprocess.call(
-            f'{new_path}/python.exe -m pip install --upgrade pip uv && exit',
-            shell=True,
-            cwd=user_profile,
-        )
-        # Create venv using uv
-        subprocess.call(
-            f'{new_path}/python.exe -m uv venv {venv_dir} && exit"',
             shell=True,
             cwd=user_profile,
         )

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -56,13 +56,13 @@ def create_venv_windows(venv_dir: str, py_path: str):
         print(f"New PATH: {new_path.split(';')[1]}")
         # Backup method
         subprocess.call(
-            f'"{new_path.split(";")[1]}\python.exe" -m pip install --upgrade pip uv && exit',
+            f'{new_path.split(";")[0].replace(" ", "` ")}\python.exe -m pip install --upgrade pip uv && exit',
             shell=True,
             cwd=user_profile,
         )
         # Create venv using uv
         subprocess.call(
-            f'"{new_path.split(";")[1]}\python.exe" -m uv venv {venv_dir} && exit"',
+            f'{new_path.split(";")[0].replace(" ", "` ")}\python.exe -m uv venv {venv_dir} && exit',
             shell=True,
             cwd=user_profile,
         )

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -49,19 +49,36 @@ def create_venv_windows(venv_dir: str, py_path: str):
     scripts_path = os.path.join(py_path, "Scripts")
     new_path = f"{py_path};{scripts_path};%PATH%"
 
+    
     # Update the package managers
-    subprocess.call(
-        f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
-        shell=True,
-        cwd=user_profile,
-    )
+    try:
+        subprocess.call(
+            f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
+            shell=True,
+            cwd=user_profile,
+        )
 
-    # Create venv using uv
-    subprocess.call(
-        f'start /w /min cmd /K "set PATH={new_path} && python -m uv venv {venv_dir} && exit"',
-        shell=True,
-        cwd=user_profile,
-    )
+        # Create venv using uv
+        subprocess.call(
+            f'start /w /min cmd /K "set PATH={new_path} && python -m uv venv {venv_dir} && exit"',
+            shell=True,
+            cwd=user_profile,
+        )
+    except Exception as e:
+        print(f"Error creating virtual environment: {e}")
+        
+        # Backup method
+        subprocess.call(
+            f'{new_path}/python.exe -m pip install --upgrade pip uv && exit',
+            shell=True,
+            cwd=user_profile,
+        )
+        # Create venv using uv
+        subprocess.call(
+            f'{new_path}/python.exe -m uv venv {venv_dir} && exit"',
+            shell=True,
+            cwd=user_profile,
+        )
 
 
 def create_venv_windows_conda(venv_dir: str, py_path: str):

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -52,9 +52,12 @@ def create_venv_windows(venv_dir: str, py_path: str):
     
     # Update the package managers
     try:
+        new_path = new_path.split(";")[0] + "\python.exe"
+        
+        # Update pip and uv using the new path
         LOG.debug("Updating package managers - pip & uv...")
         subprocess.call(
-            f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
+            f'"{new_path}" -m pip install --upgrade pip uv && exit',
             shell=True,
             cwd=user_profile,
         )
@@ -62,28 +65,12 @@ def create_venv_windows(venv_dir: str, py_path: str):
         # Create venv using uv
         LOG.debug("Creating virtual environment using uv...")
         subprocess.call(
-            f'start /w /min cmd /K "set PATH={new_path} && python -m uv venv {venv_dir} && exit"',
+            f'"{new_path}" -m uv venv {venv_dir} && exit',
             shell=True,
             cwd=user_profile,
         )
     except Exception as e:
         LOG.debug(f"Error creating virtual environment: {e}")
-        LOG.debug("Trying to create virtual environment using backup method...")
-        
-        new_path = new_path.split(";")[0] + "\python.exe"
-        
-        # Backup method
-        subprocess.call(
-            f'"{new_path}" -m pip install --upgrade pip uv && exit',
-            shell=True,
-            cwd=user_profile,
-        )
-        # Create venv using uv
-        subprocess.call(
-            f'"{new_path}" -m uv venv {venv_dir} && exit',
-            shell=True,
-            cwd=user_profile,
-        )
 
 
 def create_venv_windows_conda(venv_dir: str, py_path: str):

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -53,7 +53,7 @@ def create_venv_windows(venv_dir: str, py_path: str):
     # Update the package managers
     try:
         print("Updating package managers...")
-        print(f"New PATH: {new_path}")
+        print(f"New PATH: {new_path.split(';')[1]}")
         subprocess.call(
             f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
             shell=True,

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -53,16 +53,16 @@ def create_venv_windows(venv_dir: str, py_path: str):
     # Update the package managers
     try:
         print("Updating package managers...")
-        print(f"New PATH: {new_path.split(';')[1]}")
+        print(f"New PATH: {new_path.split(';')[0]}")
         # Backup method
         subprocess.call(
-            f'{new_path.split(";")[0].replace(" ", "` ")}\python.exe -m pip install --upgrade pip uv && exit',
+            f'"{new_path.split(";")[0].replace(" ", "` ")}\python.exe" -m pip install --upgrade pip uv && exit',
             shell=True,
             cwd=user_profile,
         )
         # Create venv using uv
         subprocess.call(
-            f'{new_path.split(";")[0].replace(" ", "` ")}\python.exe -m uv venv {venv_dir} && exit',
+            f'"{new_path.split(";")[0].replace(" ", "` ")}\python.exe" -m uv venv {venv_dir} && exit',
             shell=True,
             cwd=user_profile,
         )

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -53,16 +53,18 @@ def create_venv_windows(venv_dir: str, py_path: str):
     # Update the package managers
     try:
         print("Updating package managers...")
-        print(f"New PATH: {new_path.split(';')[0]}")
+        
+        new_path = new_path.split(";")[0].replace(" ", "` ") + "\python.exe"
+        print(f"New path: {new_path}")
         # Backup method
         subprocess.call(
-            f'"{new_path.split(";")[0].replace(" ", "` ")}\python.exe" -m pip install --upgrade pip uv && exit',
+            f'{new_path} -m pip install --upgrade pip uv && exit',
             shell=True,
             cwd=user_profile,
         )
         # Create venv using uv
         subprocess.call(
-            f'"{new_path.split(";")[0].replace(" ", "` ")}\python.exe" -m uv venv {venv_dir} && exit',
+            f'{new_path} -m uv venv {venv_dir} && exit',
             shell=True,
             cwd=user_profile,
         )

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -58,13 +58,13 @@ def create_venv_windows(venv_dir: str, py_path: str):
         print(f"New path: {new_path}")
         # Backup method
         subprocess.call(
-            f'{new_path} -m pip install --upgrade pip uv && exit',
+            f'"{new_path}" -m pip install --upgrade pip uv && exit',
             shell=True,
             cwd=user_profile,
         )
         # Create venv using uv
         subprocess.call(
-            f'{new_path} -m uv venv {venv_dir} && exit',
+            f'"{new_path}" -m uv venv {venv_dir} && exit',
             shell=True,
             cwd=user_profile,
         )

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -52,6 +52,8 @@ def create_venv_windows(venv_dir: str, py_path: str):
     
     # Update the package managers
     try:
+        print("Updating package managers...")
+        print(f"New PATH: {new_path}")
         subprocess.call(
             f'start /w /min cmd /K "set PATH={new_path} && python -m pip install --upgrade pip uv && exit"',
             shell=True,

--- a/src/ansys/tools/installer/windows_functions.py
+++ b/src/ansys/tools/installer/windows_functions.py
@@ -54,7 +54,7 @@ def create_venv_windows(venv_dir: str, py_path: str):
     try:
         print("Updating package managers...")
         
-        new_path = new_path.split(";")[0].replace(" ", "` ") + "\python.exe"
+        new_path = new_path.split(";")[0] + "\python.exe"
         print(f"New path: {new_path}")
         # Backup method
         subprocess.call(


### PR DESCRIPTION
Fixing a bug with uv venv creation. On some windows machines, if the PATH is not configured properly, the venv creation might not work. 

Solution - Using absolute python path during subprocess call